### PR TITLE
CSS Adjustments for smaller screens

### DIFF
--- a/include/header.php
+++ b/include/header.php
@@ -21,7 +21,7 @@
   $assets = array(
     'links' => array(
       array(
-        'src' => getRoot() . '/css/style.css?v14',
+        'src' => getRoot() . '/css/style.css?v15',
         'rel' => "stylesheet",
         'type' => "text/css",
         'media' => 'screen'

--- a/include/header.php
+++ b/include/header.php
@@ -212,6 +212,7 @@
 
        //Keeps Paste Text feature active until user deselects the Paste as Text button
        paste_text_sticky : true,
+       content_style: "@media (max-width: 750px) { body { margin: 8px 16px !important; } }",
        //select pasteAsPlainText on startup
        setup : function(ed) {
            ed.onInit.add(function(ed) {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -768,16 +768,11 @@ body #footer span a:hover {
   }
   #stage #text p,
   #stage #text2 p {
-    font-size: 18px!important;
-    line-height: 26px!important;
-  }
-  #stage #text p.small,
-  #stage #text2 p.small {
-    font-size: 17px!important;
-    line-height: 23px!important;
+    font-size: 20px!important;
+    line-height: 27px!important;
   }
   #stage .inner #text p {
-    margin-bottom: 20px !important;
+    margin-bottom: 15px !important;
   }
   body #editor_controls .submit {
     padding-top: 10px !important;
@@ -842,6 +837,11 @@ body #footer span a:hover {
   }
   .dk_container a {
     width: 80px !important;
+  }
+  #stage #text p,
+  #stage #text2 p {
+    font-size: 18px!important;
+    line-height: 26px!important;
   }
 }
 @media (max-width: 400px) {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -364,6 +364,7 @@ body #header #container #nav a {
   text-decoration: none;
   font-weight: 600;
   margin-right: 30px;
+  white-space: nowrap;
 }
 body #header #container #nav a.active,
 body #header #container #nav a:hover {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -814,13 +814,6 @@ body #footer span a:hover {
     width: 100% !important;
     float: none !important;
   }
-}
-@media (max-width: 400px) {
-  #header #nav a {
-    font-size: 15px!important;
-  }
-}
-@media (max-width: 450px) {
   body #editor_controls .dropdown {
     width: 100%;
     float: none;
@@ -829,6 +822,13 @@ body #footer span a:hover {
     margin-right: auto;
     height: 40px;
   }
+}
+@media (max-width: 400px) {
+  #header #nav a {
+    font-size: 15px!important;
+  }
+}
+@media (max-width: 450px) {
   body #editor_controls {
     padding: 20px 10px;
   }

--- a/www/css/style.less
+++ b/www/css/style.less
@@ -249,6 +249,7 @@ body {
           text-decoration: none;
           font-weight: 600;
           margin-right: 30px;
+          white-space: nowrap;
           &.active, &:hover {
             color: @blue;
           }

--- a/www/css/style.less
+++ b/www/css/style.less
@@ -715,6 +715,15 @@ body {
     width: 100% !important;
     float: none !important;
   }
+  body #editor_controls .dropdown
+  {
+    width: 100%;
+    float: none;
+    clear: both;
+    margin-left: auto;
+    margin-right: auto;
+    height: 40px;
+  }
 }
 
 @media (max-width: 400px) {
@@ -728,15 +737,6 @@ body {
 }
 
 @media (max-width: 450px) {
-  body #editor_controls .dropdown
-  {
-    width: 100%;
-    float: none;
-    clear: both;
-    margin-left: auto;
-    margin-right: auto;
-    height: 40px;
-  }
   body #editor_controls
   {
     padding: 20px 10px;

--- a/www/css/style.less
+++ b/www/css/style.less
@@ -663,16 +663,12 @@ body {
   #stage {
     #text, #text2 {
       p {
-        font-size: 18px!important;
-        line-height: 26px!important;
-        &.small {
-          font-size: 17px!important;
-          line-height: 23px!important;
-        }
+        font-size: 20px!important;
+        line-height: 27px!important;
       }
     }
     .inner #text p {
-      margin-bottom: 20px !important;
+      margin-bottom: 15px !important;
     }
   }
   body #editor_controls .submit {
@@ -752,6 +748,11 @@ body {
   .dk_container a
   {
     width: 80px !important;
+  }
+  #stage #text p,
+  #stage #text2 p {
+    font-size: 18px!important;
+    line-height: 26px!important;
   }
 }
 


### PR DESCRIPTION
* Significantly reduce margins within TinyMCE editor on smaller screens
* Do not line-break within navigation items
* Fix language/country display dropdown issue on smaller screens
* Adjust font sizes of headings on smaller screens